### PR TITLE
Create '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
The `.gitignore` file has been added to exclude the `node_modules` directory, which contains package dependencies and does not need to be included in version control.